### PR TITLE
ci: resolve merge conflict markers in claude-autofix workflow

### DIFF
--- a/.github/workflows/claude-autofix.yml
+++ b/.github/workflows/claude-autofix.yml
@@ -65,11 +65,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-<<<<<<< Updated upstream
-          claude_args: '--model claude-opus-4-7 --max-turns 60'
-=======
-          claude_args: '--model claude-opus-4-7 --max-turns 15 --permission-mode bypassPermissions'
->>>>>>> Stashed changes
+          claude_args: '--model claude-opus-4-7 --max-turns 60 --permission-mode bypassPermissions'
           prompt: |
             You are fixing a failing CI build on PR #${{ steps.pr.outputs.number }} (branch `${{ steps.pr.outputs.head_ref }}`).
             The "PR Build" workflow failed on one or more of: frontend, backend, e2e.


### PR DESCRIPTION
## Summary
- The `claude-autofix.yml` workflow on `main` was committed with unresolved git merge conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`), making it invalid YAML — so the autofix never actually ran on any failing PR build.
- That's the answer to "did it run with bypass permissions?": it didn't run at all. PR #16 (the deliberately-broken-frontend test PR) shows `frontend` failing with no autofix run created.
- Resolved the conflict by combining both sides: keep `--max-turns 60` (upstream) and add `--permission-mode bypassPermissions` so the action can run npm/dotnet builds, `git push`, and `gh pr merge` without permission prompts.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/claude-autofix.yml'))"` parses cleanly
- [x] `grep -rn '<<<<<<<\|>>>>>>>\|=======' .github/` returns nothing
- [ ] After this PR auto-merges to `main`, push a trivial change to PR #16's branch to re-trigger PR Build → autofix should now run and push a fix commit, then enable auto-merge

https://claude.ai/code/session_014wtAXgSkhueTC7cMgtePvn

---
_Generated by [Claude Code](https://claude.ai/code/session_014wtAXgSkhueTC7cMgtePvn)_