### PR TITLE
Character win-rate plot mockups (4 variants)

### DIFF
--- a/client/src/app/router/Routes.tsx
+++ b/client/src/app/router/Routes.tsx
@@ -40,6 +40,10 @@ export const router = createBrowserRouter([
           },
           { path: "leagues/:competitionId/stats", element: <LeagueTabs key="stats" tab="stats" /> },
           {
+            path: "leagues/:competitionId/mockups",
+            element: <LeagueTabs key="mockups" tab="mockups" />,
+          },
+          {
             path: "leagues/:competitionId/bracket/:bracketNumber/match/:matchNumber",
             element: <MatchDetails type="league" />,
           },

--- a/client/src/features/leagues/LeagueTabs.tsx
+++ b/client/src/features/leagues/LeagueTabs.tsx
@@ -2,6 +2,7 @@ import {
   BarChart,
   Description as DescriptionIcon,
   EmojiEvents,
+  Science as ScienceIcon,
   SportsEsports,
 } from "@mui/icons-material";
 import { Box, Tab, Tabs, Typography } from "@mui/material";
@@ -12,6 +13,7 @@ import EmptyState from "../../app/shared/components/EmptyState";
 import LoadingSkeleton from "../../app/shared/components/LoadingSkeleton";
 import { useLeagues } from "../../lib/hooks/useLeagues";
 import MatchesList from "../matches/MatchesList";
+import CharacterWinRateMockups from "../stats/CharacterWinRateMockups";
 import LeagueStats from "../stats/LeagueStats";
 import Description from "./Description";
 import Leaderboard from "./Leaderboard";
@@ -23,7 +25,7 @@ export default function LeagueTabs({ tab }: Props) {
   const { competitionId } = useParams();
   const navigate = useNavigate();
   const { league, isLeagueLoading } = useLeagues(competitionId);
-  const pathMap = ["description", "leaderboard", "matches", "stats"];
+  const pathMap = ["description", "leaderboard", "matches", "stats", "mockups"];
 
   const handleChange = (_: React.SyntheticEvent, newValue: number) => {
     navigate(`/leagues/${competitionId}/${pathMap[newValue]}`);
@@ -79,6 +81,7 @@ export default function LeagueTabs({ tab }: Props) {
             <Tab icon={<EmojiEvents fontSize="small" />} iconPosition="start" label="Leaderboard" />
             <Tab icon={<SportsEsports fontSize="small" />} iconPosition="start" label="Matches" />
             <Tab icon={<BarChart fontSize="small" />} iconPosition="start" label="Stats" />
+            <Tab icon={<ScienceIcon fontSize="small" />} iconPosition="start" label="Mockups" />
           </Tabs>
         </Box>
         <Box
@@ -95,6 +98,7 @@ export default function LeagueTabs({ tab }: Props) {
           {tab === "leaderboard" && <Leaderboard />}
           {tab === "matches" && <MatchesList />}
           {tab === "stats" && <LeagueStats />}
+          {tab === "mockups" && <CharacterWinRateMockups />}
         </Box>
       </Box>
     </Box>

--- a/client/src/features/stats/CharacterWinRateMockups.tsx
+++ b/client/src/features/stats/CharacterWinRateMockups.tsx
@@ -1,0 +1,83 @@
+import { BarChart as BarChartIcon } from "@mui/icons-material";
+import { Box, Divider, Paper, Typography } from "@mui/material";
+import type { ComponentType } from "react";
+import { useParams } from "react-router";
+
+import EmptyState from "../../app/shared/components/EmptyState";
+import LoadingSkeleton from "../../app/shared/components/LoadingSkeleton";
+import { useCharacters } from "../../lib/hooks/useCharacters";
+import { useLeagues } from "../../lib/hooks/useLeagues";
+import { computeCharacterWinRates } from "../../lib/util/statUtils";
+import {
+  MockupA_VerticalBubble,
+  MockupB_Beeswarm,
+  MockupC_TwoAxis,
+  MockupD_Lollipop,
+} from "./charts/mockups";
+
+const variants: {
+  label: string;
+  blurb: string;
+  Component: ComponentType<{ data: CharacterWinRate[] }>;
+}[] = [
+  {
+    label: "A. Vertical Bubble (Win Rate on Y)",
+    blurb:
+      "Y = Win Rate % (full 0–100 stretches over the tall mobile canvas), X = jitter, bubble size = rounds played. Reference line at 50%.",
+    Component: MockupA_VerticalBubble,
+  },
+  {
+    label: "B. Beeswarm (Y = Rounds Played)",
+    blurb:
+      "Same axes as today, but X positions are collision-resolved instead of random — bubbles always pack tightly without overlap. Bubble size = win rate.",
+    Component: MockupB_Beeswarm,
+  },
+  {
+    label: "C. Two-axis log scatter",
+    blurb:
+      "X = Rounds Played (log scale spreads the low-volume cluster), Y = Win Rate %. Both axes meaningful, fixed-size portraits.",
+    Component: MockupC_TwoAxis,
+  },
+  {
+    label: "D. Lollipop, sorted by volume",
+    blurb:
+      "Characters laid out on a fixed grid (most played → least played), Y = Win Rate %, stem from 50% baseline. Zero overlap by construction. Bubble size = rounds played.",
+    Component: MockupD_Lollipop,
+  },
+];
+
+export default function CharacterWinRateMockups() {
+  const { competitionId } = useParams();
+  const { league, isLeagueLoading } = useLeagues(competitionId);
+  const { characters } = useCharacters();
+
+  if (isLeagueLoading) return <LoadingSkeleton variant="chart" count={4} />;
+  if (!league || !characters)
+    return (
+      <EmptyState icon={<BarChartIcon sx={{ fontSize: 48 }} />} message="No league stats yet" />
+    );
+
+  const charStats = computeCharacterWinRates(league.matches, characters);
+
+  return (
+    <Box>
+      <Typography variant="body2" color="text.secondary" mb={2}>
+        Comparison of {variants.length} character-winrate plot variants on the same dataset (
+        {charStats.filter((c) => c.total >= 5).length} characters with 5+ rounds).
+      </Typography>
+      {variants.map((v, i) => (
+        <Paper key={v.label} variant="outlined" sx={{ p: 2, mb: 3 }}>
+          <Typography variant="h6" fontWeight="bold" sx={{ color: "primary.main" }}>
+            {v.label}
+          </Typography>
+          <Typography variant="body2" color="text.secondary" mb={1}>
+            {v.blurb}
+          </Typography>
+          <Divider sx={{ mb: 1 }} />
+          <v.Component data={charStats} />
+          {i < variants.length - 1 && <Box sx={{ height: 8 }} />}
+        </Paper>
+      ))}
+    </Box>
+  );
+}

--- a/client/src/features/stats/charts/mockups/CharacterPortraitDot.tsx
+++ b/client/src/features/stats/charts/mockups/CharacterPortraitDot.tsx
@@ -1,0 +1,33 @@
+import { useTheme } from "@mui/material";
+
+type Props = {
+  cx: number;
+  cy: number;
+  size: number;
+  imageUrl: string;
+  name: string;
+  uid: string;
+};
+
+export default function CharacterPortraitDot({ cx, cy, size, imageUrl, name, uid }: Props) {
+  const theme = useTheme();
+  const clipId = `clip-${uid}-${name.replace(/\s+/g, "")}`;
+  return (
+    <g>
+      <defs>
+        <clipPath id={clipId}>
+          <circle cx={cx} cy={cy} r={size / 2} />
+        </clipPath>
+      </defs>
+      <circle cx={cx} cy={cy} r={size / 2 + 2} fill={theme.palette.divider} />
+      <image
+        href={imageUrl}
+        x={cx - size / 2}
+        y={cy - size / 2}
+        width={size}
+        height={size}
+        clipPath={`url(#${clipId})`}
+      />
+    </g>
+  );
+}

--- a/client/src/features/stats/charts/mockups/MockupA_VerticalBubble.tsx
+++ b/client/src/features/stats/charts/mockups/MockupA_VerticalBubble.tsx
@@ -1,0 +1,143 @@
+import { Box, Typography, useTheme } from "@mui/material";
+import { useCallback, useMemo, useState } from "react";
+import {
+  CartesianGrid,
+  ReferenceLine,
+  ResponsiveContainer,
+  Scatter,
+  ScatterChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import CharacterPortraitDot from "./CharacterPortraitDot";
+
+const MIN_ROUNDS = 5;
+const MIN_SIZE = 22;
+const MAX_SIZE = 46;
+
+function seededRandom(seed: string) {
+  let hash = 0;
+  for (let i = 0; i < seed.length; i++) {
+    hash = (hash << 5) - hash + seed.charCodeAt(i);
+    hash |= 0;
+  }
+  return ((hash & 0x7fffffff) % 1000) / 1000;
+}
+
+type Props = { data: CharacterWinRate[] };
+
+export default function MockupA_VerticalBubble({ data }: Props) {
+  const theme = useTheme();
+  const [dims, setDims] = useState<{ w: number; h: number } | null>(null);
+  const containerRef = useCallback((node: HTMLDivElement | null) => {
+    if (!node) return;
+    const observer = new ResizeObserver((entries) => {
+      const { width, height } = entries[0].contentRect;
+      if (width <= 0 || height <= 0) return;
+      setDims((prev) => (prev?.w === width && prev?.h === height ? prev : { w: width, h: height }));
+    });
+    observer.observe(node);
+  }, []);
+
+  const scatterData = useMemo(() => {
+    const filtered = data.filter((s) => s.total >= MIN_ROUNDS);
+    const minTotal = Math.min(...filtered.map((s) => s.total));
+    const maxTotal = Math.max(...filtered.map((s) => s.total));
+    const range = maxTotal - minTotal || 1;
+    return filtered.map((s) => {
+      const norm = (s.total - minTotal) / range;
+      const size = MIN_SIZE + norm * (MAX_SIZE - MIN_SIZE);
+      return {
+        x: (seededRandom(s.name + "vb") - 0.5) * 0.8,
+        y: s.winRate,
+        size: Math.round(size),
+        ...s,
+      };
+    });
+  }, [data]);
+
+  return (
+    <Box ref={containerRef} sx={{ width: "100%", height: 500 }}>
+      {scatterData.length === 0 ? (
+        <Typography variant="body2" color="text.secondary" sx={{ p: 2 }}>
+          No characters with {MIN_ROUNDS}+ rounds played.
+        </Typography>
+      ) : (
+        dims && (
+          <ResponsiveContainer width={dims.w} height={dims.h}>
+            <ScatterChart margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" opacity={0.3} vertical={false} />
+              <XAxis type="number" dataKey="x" domain={[-1, 1]} hide />
+              <YAxis
+                type="number"
+                dataKey="y"
+                domain={[0, 100]}
+                ticks={[0, 25, 50, 75, 100]}
+                tickFormatter={(v) => `${v}%`}
+                label={{
+                  value: "Win Rate",
+                  angle: -90,
+                  position: "insideLeft",
+                  style: { fontSize: 12 },
+                }}
+              />
+              <ReferenceLine
+                y={50}
+                stroke={theme.palette.warning.main}
+                strokeDasharray="4 4"
+                opacity={0.6}
+              />
+              <Tooltip
+                content={({ payload }) => {
+                  if (!payload?.length) return null;
+                  const d = payload[0].payload as (typeof scatterData)[number];
+                  return (
+                    <Box
+                      sx={{
+                        bgcolor: "background.paper",
+                        border: "1px solid",
+                        borderColor: "divider",
+                        borderRadius: 1,
+                        p: 1.5,
+                      }}
+                    >
+                      <Typography variant="body2" fontWeight="bold">
+                        {d.name}
+                      </Typography>
+                      <Typography variant="caption" display="block">
+                        Win Rate: {d.winRate}%
+                      </Typography>
+                      <Typography variant="caption">Rounds: {d.total}</Typography>
+                    </Box>
+                  );
+                }}
+              />
+              <Scatter
+                data={scatterData}
+                shape={(props: unknown) => {
+                  const p = props as {
+                    cx: number;
+                    cy: number;
+                    payload: (typeof scatterData)[number];
+                  };
+                  return (
+                    <CharacterPortraitDot
+                      cx={p.cx}
+                      cy={p.cy}
+                      size={p.payload.size}
+                      imageUrl={p.payload.imageUrl}
+                      name={p.payload.name}
+                      uid="vb"
+                    />
+                  );
+                }}
+              />
+            </ScatterChart>
+          </ResponsiveContainer>
+        )
+      )}
+    </Box>
+  );
+}

--- a/client/src/features/stats/charts/mockups/MockupB_Beeswarm.tsx
+++ b/client/src/features/stats/charts/mockups/MockupB_Beeswarm.tsx
@@ -1,0 +1,171 @@
+import { Box, Typography, useTheme } from "@mui/material";
+import { useCallback, useMemo, useState } from "react";
+
+import CharacterPortraitDot from "./CharacterPortraitDot";
+
+const MIN_ROUNDS = 5;
+const MIN_SIZE = 26;
+const MAX_SIZE = 46;
+const PAD_LEFT = 56;
+const PAD_RIGHT = 16;
+const PAD_TOP = 24;
+const PAD_BOTTOM = 36;
+
+type Props = { data: CharacterWinRate[] };
+
+type Placed = {
+  character: CharacterWinRate;
+  size: number;
+  cx: number;
+  cy: number;
+};
+
+export default function MockupB_Beeswarm({ data }: Props) {
+  const theme = useTheme();
+  const [dims, setDims] = useState<{ w: number; h: number } | null>(null);
+  const containerRef = useCallback((node: HTMLDivElement | null) => {
+    if (!node) return;
+    const observer = new ResizeObserver((entries) => {
+      const { width, height } = entries[0].contentRect;
+      if (width <= 0 || height <= 0) return;
+      setDims((prev) => (prev?.w === width && prev?.h === height ? prev : { w: width, h: height }));
+    });
+    observer.observe(node);
+  }, []);
+
+  const filtered = useMemo(() => data.filter((s) => s.total >= MIN_ROUNDS), [data]);
+
+  const yDomain = useMemo(() => {
+    if (filtered.length === 0) return [0, 10];
+    const totals = filtered.map((s) => s.total);
+    const min = Math.min(...totals);
+    const max = Math.max(...totals);
+    const pad = Math.max((max - min) * 0.1, 2);
+    return [Math.max(0, Math.floor(min - pad)), Math.ceil(max + pad)];
+  }, [filtered]);
+
+  const placed: Placed[] = useMemo(() => {
+    if (!dims || filtered.length === 0) return [];
+    const minWr = Math.min(...filtered.map((s) => s.winRate));
+    const maxWr = Math.max(...filtered.map((s) => s.winRate));
+    const wrRange = maxWr - minWr || 1;
+
+    const plotW = dims.w - PAD_LEFT - PAD_RIGHT;
+    const plotH = dims.h - PAD_TOP - PAD_BOTTOM;
+    const cxCenter = PAD_LEFT + plotW / 2;
+    const [yMin, yMax] = yDomain;
+    const yToPx = (y: number) => PAD_TOP + plotH - ((y - yMin) / (yMax - yMin)) * plotH;
+
+    const sorted = [...filtered].sort((a, b) => b.total - a.total);
+    const out: Placed[] = [];
+    for (const c of sorted) {
+      const sizeNorm = (c.winRate - minWr) / wrRange;
+      const size = MIN_SIZE + sizeNorm * (MAX_SIZE - MIN_SIZE);
+      const r = size / 2 + 2;
+      const cy = yToPx(c.total);
+
+      let cx = cxCenter;
+      let attempts = 0;
+      const direction = sorted.indexOf(c) % 2 === 0 ? 1 : -1;
+      while (attempts < 200) {
+        const collides = out.some((p) => {
+          const dx = p.cx - cx;
+          const dy = p.cy - cy;
+          const minDist = p.size / 2 + size / 2 + 4;
+          return dx * dx + dy * dy < minDist * minDist;
+        });
+        if (!collides) break;
+        const offset = (Math.floor(attempts / 2) + 1) * (r * 0.6);
+        cx = cxCenter + (attempts % 2 === 0 ? direction : -direction) * offset;
+        attempts += 1;
+      }
+      cx = Math.max(PAD_LEFT + r, Math.min(PAD_LEFT + plotW - r, cx));
+      out.push({ character: c, size, cx, cy });
+    }
+    return out;
+  }, [filtered, dims, yDomain]);
+
+  const yTicks = useMemo(() => {
+    const [yMin, yMax] = yDomain;
+    const span = yMax - yMin;
+    const step = Math.max(1, Math.round(span / 5));
+    const ticks: number[] = [];
+    for (let v = Math.ceil(yMin / step) * step; v <= yMax; v += step) ticks.push(v);
+    return ticks;
+  }, [yDomain]);
+
+  return (
+    <Box ref={containerRef} sx={{ width: "100%", height: 500 }}>
+      {filtered.length === 0 && (
+        <Typography variant="body2" color="text.secondary" sx={{ p: 2 }}>
+          No characters with {MIN_ROUNDS}+ rounds played.
+        </Typography>
+      )}
+      {dims && filtered.length > 0 && (
+        <svg width={dims.w} height={dims.h}>
+          {yTicks.map((t) => {
+            const [yMin, yMax] = yDomain;
+            const plotH = dims.h - PAD_TOP - PAD_BOTTOM;
+            const y = PAD_TOP + plotH - ((t - yMin) / (yMax - yMin)) * plotH;
+            return (
+              <g key={t}>
+                <line
+                  x1={PAD_LEFT}
+                  x2={dims.w - PAD_RIGHT}
+                  y1={y}
+                  y2={y}
+                  stroke={theme.palette.divider}
+                  strokeDasharray="3 3"
+                  opacity={0.5}
+                />
+                <text
+                  x={PAD_LEFT - 8}
+                  y={y + 4}
+                  textAnchor="end"
+                  fontSize={11}
+                  fill={theme.palette.text.secondary}
+                >
+                  {t}
+                </text>
+              </g>
+            );
+          })}
+          <text
+            x={16}
+            y={PAD_TOP + (dims.h - PAD_TOP - PAD_BOTTOM) / 2}
+            transform={`rotate(-90, 16, ${PAD_TOP + (dims.h - PAD_TOP - PAD_BOTTOM) / 2})`}
+            textAnchor="middle"
+            fontSize={12}
+            fill={theme.palette.text.secondary}
+          >
+            Rounds Played
+          </text>
+          <text
+            x={dims.w / 2}
+            y={dims.h - 8}
+            textAnchor="middle"
+            fontSize={11}
+            fill={theme.palette.text.secondary}
+          >
+            (bubble size = win rate)
+          </text>
+          {placed.map((p) => (
+            <g key={p.character.characterId}>
+              <CharacterPortraitDot
+                cx={p.cx}
+                cy={p.cy}
+                size={p.size}
+                imageUrl={p.character.imageUrl}
+                name={p.character.name}
+                uid="bs"
+              />
+              <title>
+                {p.character.name} — {p.character.winRate}% over {p.character.total} rounds
+              </title>
+            </g>
+          ))}
+        </svg>
+      )}
+    </Box>
+  );
+}

--- a/client/src/features/stats/charts/mockups/MockupC_TwoAxis.tsx
+++ b/client/src/features/stats/charts/mockups/MockupC_TwoAxis.tsx
@@ -1,0 +1,141 @@
+import { Box, Typography, useTheme } from "@mui/material";
+import { useCallback, useMemo, useState } from "react";
+import {
+  CartesianGrid,
+  ReferenceLine,
+  ResponsiveContainer,
+  Scatter,
+  ScatterChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import CharacterPortraitDot from "./CharacterPortraitDot";
+
+const MIN_ROUNDS = 5;
+const DOT_SIZE = 32;
+
+type Props = { data: CharacterWinRate[] };
+
+export default function MockupC_TwoAxis({ data }: Props) {
+  const theme = useTheme();
+  const [dims, setDims] = useState<{ w: number; h: number } | null>(null);
+  const containerRef = useCallback((node: HTMLDivElement | null) => {
+    if (!node) return;
+    const observer = new ResizeObserver((entries) => {
+      const { width, height } = entries[0].contentRect;
+      if (width <= 0 || height <= 0) return;
+      setDims((prev) => (prev?.w === width && prev?.h === height ? prev : { w: width, h: height }));
+    });
+    observer.observe(node);
+  }, []);
+
+  const scatterData = useMemo(() => {
+    return data.filter((s) => s.total >= MIN_ROUNDS).map((s) => ({ ...s, x: s.total, y: s.winRate }));
+  }, [data]);
+
+  const xDomain = useMemo(() => {
+    if (scatterData.length === 0) return [1, 10];
+    const totals = scatterData.map((d) => d.total);
+    const min = Math.max(1, Math.min(...totals));
+    const max = Math.max(...totals);
+    return [Math.max(1, Math.floor(min * 0.8)), Math.ceil(max * 1.1)];
+  }, [scatterData]);
+
+  return (
+    <Box ref={containerRef} sx={{ width: "100%", height: 500 }}>
+      {scatterData.length === 0 ? (
+        <Typography variant="body2" color="text.secondary" sx={{ p: 2 }}>
+          No characters with {MIN_ROUNDS}+ rounds played.
+        </Typography>
+      ) : (
+        dims && (
+          <ResponsiveContainer width={dims.w} height={dims.h}>
+            <ScatterChart margin={{ top: 20, right: 24, bottom: 50, left: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" opacity={0.3} />
+              <XAxis
+                type="number"
+                dataKey="x"
+                scale="log"
+                domain={xDomain}
+                allowDataOverflow
+                tickFormatter={(v) => String(Math.round(v))}
+                label={{
+                  value: "Rounds Played (log)",
+                  position: "insideBottom",
+                  offset: -10,
+                  style: { fontSize: 12 },
+                }}
+              />
+              <YAxis
+                type="number"
+                dataKey="y"
+                domain={[0, 100]}
+                ticks={[0, 25, 50, 75, 100]}
+                tickFormatter={(v) => `${v}%`}
+                label={{
+                  value: "Win Rate",
+                  angle: -90,
+                  position: "insideLeft",
+                  style: { fontSize: 12 },
+                }}
+              />
+              <ReferenceLine
+                y={50}
+                stroke={theme.palette.warning.main}
+                strokeDasharray="4 4"
+                opacity={0.6}
+              />
+              <Tooltip
+                content={({ payload }) => {
+                  if (!payload?.length) return null;
+                  const d = payload[0].payload as (typeof scatterData)[number];
+                  return (
+                    <Box
+                      sx={{
+                        bgcolor: "background.paper",
+                        border: "1px solid",
+                        borderColor: "divider",
+                        borderRadius: 1,
+                        p: 1.5,
+                      }}
+                    >
+                      <Typography variant="body2" fontWeight="bold">
+                        {d.name}
+                      </Typography>
+                      <Typography variant="caption" display="block">
+                        Win Rate: {d.winRate}%
+                      </Typography>
+                      <Typography variant="caption">Rounds: {d.total}</Typography>
+                    </Box>
+                  );
+                }}
+              />
+              <Scatter
+                data={scatterData}
+                shape={(props: unknown) => {
+                  const p = props as {
+                    cx: number;
+                    cy: number;
+                    payload: (typeof scatterData)[number];
+                  };
+                  return (
+                    <CharacterPortraitDot
+                      cx={p.cx}
+                      cy={p.cy}
+                      size={DOT_SIZE}
+                      imageUrl={p.payload.imageUrl}
+                      name={p.payload.name}
+                      uid="ta"
+                    />
+                  );
+                }}
+              />
+            </ScatterChart>
+          </ResponsiveContainer>
+        )
+      )}
+    </Box>
+  );
+}

--- a/client/src/features/stats/charts/mockups/MockupD_Lollipop.tsx
+++ b/client/src/features/stats/charts/mockups/MockupD_Lollipop.tsx
@@ -1,0 +1,176 @@
+import { Box, Typography, useTheme } from "@mui/material";
+import { useCallback, useMemo, useState } from "react";
+
+import CharacterPortraitDot from "./CharacterPortraitDot";
+
+const MIN_ROUNDS = 5;
+const MIN_SIZE = 22;
+const MAX_SIZE = 40;
+const PAD_LEFT = 56;
+const PAD_RIGHT = 16;
+const PAD_TOP = 24;
+const PAD_BOTTOM = 64;
+const BASELINE_PCT = 50;
+
+type Props = { data: CharacterWinRate[] };
+
+export default function MockupD_Lollipop({ data }: Props) {
+  const theme = useTheme();
+  const [dims, setDims] = useState<{ w: number; h: number } | null>(null);
+  const [hovered, setHovered] = useState<string | null>(null);
+  const containerRef = useCallback((node: HTMLDivElement | null) => {
+    if (!node) return;
+    const observer = new ResizeObserver((entries) => {
+      const { width, height } = entries[0].contentRect;
+      if (width <= 0 || height <= 0) return;
+      setDims((prev) => (prev?.w === width && prev?.h === height ? prev : { w: width, h: height }));
+    });
+    observer.observe(node);
+  }, []);
+
+  const sorted = useMemo(
+    () => data.filter((s) => s.total >= MIN_ROUNDS).sort((a, b) => b.total - a.total),
+    [data],
+  );
+
+  if (!sorted.length) {
+    return (
+      <Box sx={{ width: "100%", height: 500 }}>
+        <Typography variant="body2" color="text.secondary" sx={{ p: 2 }}>
+          No characters with {MIN_ROUNDS}+ rounds played.
+        </Typography>
+      </Box>
+    );
+  }
+
+  const minTotal = Math.min(...sorted.map((s) => s.total));
+  const maxTotal = Math.max(...sorted.map((s) => s.total));
+  const totalRange = maxTotal - minTotal || 1;
+
+  return (
+    <Box ref={containerRef} sx={{ width: "100%", height: 520 }}>
+      {dims && (
+        <svg width={dims.w} height={dims.h}>
+          {[0, 25, 50, 75, 100].map((pct) => {
+            const plotH = dims.h - PAD_TOP - PAD_BOTTOM;
+            const y = PAD_TOP + plotH - (pct / 100) * plotH;
+            return (
+              <g key={pct}>
+                <line
+                  x1={PAD_LEFT}
+                  x2={dims.w - PAD_RIGHT}
+                  y1={y}
+                  y2={y}
+                  stroke={pct === BASELINE_PCT ? theme.palette.warning.main : theme.palette.divider}
+                  strokeDasharray={pct === BASELINE_PCT ? "5 4" : "3 3"}
+                  opacity={pct === BASELINE_PCT ? 0.6 : 0.4}
+                />
+                <text
+                  x={PAD_LEFT - 8}
+                  y={y + 4}
+                  textAnchor="end"
+                  fontSize={11}
+                  fill={theme.palette.text.secondary}
+                >
+                  {pct}%
+                </text>
+              </g>
+            );
+          })}
+          <text
+            x={16}
+            y={PAD_TOP + (dims.h - PAD_TOP - PAD_BOTTOM) / 2}
+            transform={`rotate(-90, 16, ${PAD_TOP + (dims.h - PAD_TOP - PAD_BOTTOM) / 2})`}
+            textAnchor="middle"
+            fontSize={12}
+            fill={theme.palette.text.secondary}
+          >
+            Win Rate
+          </text>
+          <text
+            x={dims.w / 2}
+            y={dims.h - 8}
+            textAnchor="middle"
+            fontSize={11}
+            fill={theme.palette.text.secondary}
+          >
+            ← Most played            Least played →
+          </text>
+          {sorted.map((c, i) => {
+            const plotW = dims.w - PAD_LEFT - PAD_RIGHT;
+            const plotH = dims.h - PAD_TOP - PAD_BOTTOM;
+            const cx =
+              sorted.length === 1
+                ? PAD_LEFT + plotW / 2
+                : PAD_LEFT + (i / (sorted.length - 1)) * plotW;
+            const cy = PAD_TOP + plotH - (c.winRate / 100) * plotH;
+            const baselineY = PAD_TOP + plotH - (BASELINE_PCT / 100) * plotH;
+            const sizeNorm = (c.total - minTotal) / totalRange;
+            const size = MIN_SIZE + sizeNorm * (MAX_SIZE - MIN_SIZE);
+            const above = c.winRate >= BASELINE_PCT;
+            const stroke = above ? theme.palette.success.main : theme.palette.error.main;
+            const isHovered = hovered === c.characterId;
+            return (
+              <g
+                key={c.characterId}
+                onMouseEnter={() => setHovered(c.characterId)}
+                onMouseLeave={() => setHovered(null)}
+                style={{ cursor: "pointer" }}
+              >
+                <line
+                  x1={cx}
+                  x2={cx}
+                  y1={baselineY}
+                  y2={cy}
+                  stroke={stroke}
+                  strokeWidth={2}
+                  opacity={0.7}
+                />
+                <CharacterPortraitDot
+                  cx={cx}
+                  cy={cy}
+                  size={size}
+                  imageUrl={c.imageUrl}
+                  name={c.name}
+                  uid="ll"
+                />
+                {isHovered && (
+                  <g>
+                    <rect
+                      x={cx - 60}
+                      y={cy - size / 2 - 44}
+                      width={120}
+                      height={36}
+                      rx={4}
+                      fill={theme.palette.background.paper}
+                      stroke={theme.palette.divider}
+                    />
+                    <text
+                      x={cx}
+                      y={cy - size / 2 - 28}
+                      textAnchor="middle"
+                      fontSize={11}
+                      fontWeight="bold"
+                      fill={theme.palette.text.primary}
+                    >
+                      {c.name}
+                    </text>
+                    <text
+                      x={cx}
+                      y={cy - size / 2 - 14}
+                      textAnchor="middle"
+                      fontSize={10}
+                      fill={theme.palette.text.secondary}
+                    >
+                      {c.winRate}% · {c.total} rds
+                    </text>
+                  </g>
+                )}
+              </g>
+            );
+          })}
+        </svg>
+      )}
+    </Box>
+  );
+}

--- a/client/src/features/stats/charts/mockups/index.ts
+++ b/client/src/features/stats/charts/mockups/index.ts
@@ -1,0 +1,4 @@
+export { default as MockupA_VerticalBubble } from "./MockupA_VerticalBubble";
+export { default as MockupB_Beeswarm } from "./MockupB_Beeswarm";
+export { default as MockupC_TwoAxis } from "./MockupC_TwoAxis";
+export { default as MockupD_Lollipop } from "./MockupD_Lollipop";


### PR DESCRIPTION
## Summary

Adds an experimental **Mockups** tab on the league view that renders four
different character win-rate plot variants on the same dataset, so we can
compare spreading strategies side-by-side and pick a direction.

All four variants reuse the existing `computeCharacterWinRates` util — no
backend changes, no schema changes.

### Variants

| | Y axis | X axis | Mark / size | Why try it |
|--|--|--|--|--|
| **A. Vertical Bubble** | Win Rate % (0–100) | Seeded jitter (hidden) | Portrait, size = rounds played | Stretches the wider 0–100% range across the tall mobile canvas; rounds played is encoded by size. |
| **B. Beeswarm** | Rounds played | **Collision-resolved** offset | Portrait, size = win rate | Same axes as today, but X positions are computed to avoid overlap instead of random — bubbles always pack tightly. |
| **C. Two-axis log scatter** | Win Rate % | Rounds Played (log) | Portrait, fixed size | Both axes meaningful; log X spreads the low-volume cluster that normally piles up. |
| **D. Lollipop sorted by volume** | Win Rate % | Rank by rounds played (fixed grid) | Portrait, size = rounds played, stem from 50% baseline | Zero overlap by construction. Ordered most-played → least-played. |

### How to view

1. Open any league, switch to the new **Mockups** tab (next to Stats)
2. Each variant has a short blurb explaining what's encoded where
3. All variants share the same `MIN_ROUNDS = 5` filter

Path: `/leagues/:competitionId/mockups`

### Files

- `client/src/features/stats/CharacterWinRateMockups.tsx` — page hosting all 4
- `client/src/features/stats/charts/mockups/MockupA_VerticalBubble.tsx`
- `client/src/features/stats/charts/mockups/MockupB_Beeswarm.tsx`
- `client/src/features/stats/charts/mockups/MockupC_TwoAxis.tsx`
- `client/src/features/stats/charts/mockups/MockupD_Lollipop.tsx`
- `client/src/features/stats/charts/mockups/CharacterPortraitDot.tsx` — shared portrait dot helper
- `client/src/features/leagues/LeagueTabs.tsx` — adds Mockups tab
- `client/src/app/router/Routes.tsx` — adds `/mockups` route

### Test plan

- [ ] `cd client && npm run build` passes (verified locally)
- [ ] Open `/leagues/<id>/mockups` on desktop, scroll through all 4 variants
- [ ] Open the same page on a phone-sized viewport — confirm vertical layout reads well
- [ ] Pick a winning variant (or remix between them) before merging into the main Stats tab

Once we settle on a direction we'll replace the existing
`CharacterWinRateScatter` and remove the Mockups tab.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CW3u53pffnrBkSgiHmV7bA)_