### PR TITLE
ci(autofix): scope stop-condition to algorithm changes, not file identity

### DIFF
--- a/.github/workflows/claude-autofix.yml
+++ b/.github/workflows/claude-autofix.yml
@@ -159,7 +159,7 @@ jobs:
             Stop conditions — post a PR comment summarizing what you found and exit without pushing if:
             - The failure looks intentional (deliberate breaking change with no matching test/code update).
             - Multiple plausible root causes; choosing wrong would mask a real bug.
-            - The fix would change composite keys, round-robin generation, the points formula, the guest-merge transaction, or auth route-param contracts — these need human review per CLAUDE.md.
+            - The fix would semantically alter composite keys, the round-robin pairing/shuffle algorithm, the points formula, the guest-merge transaction, or auth route-param contracts — these need human review per CLAUDE.md. (A trivial fix in the same file — a cast, a `using` directive, a rename of a non-domain local, a typo — does NOT count; only changes to those algorithms' behavior do.)
             - You cannot reproduce the failure and the artifacts are ambiguous.
 
             ---


### PR DESCRIPTION
## Summary

- Tightens the autofix prompt's stop-condition so a trivial fix (cast, rename of a non-domain local, typo) inside a "domain" file is no longer auto-refused.

## Why

In autofix run [#25881402216](https://github.com/Kilars/SYB2.0/actions/runs/25881402216) (PR #29), the backend failed with a single-line `long → int` cast error at `ChangeLeagueStatus.cs:207`. Claude completed in 23 turns (under the 60-turn cap, zero permission denials) and exited "success" without pushing — because the prompt's stop condition said "STOP if the fix would change round-robin generation" and that file *is* the round-robin generator. The wording gated on file identity instead of what's being changed inside the file.

New wording requires the change to *semantically alter* the algorithm before triggering a stop, and lists trivial cases that should not.

## Test plan

- [ ] Verify YAML still parses (workflow appears in Actions tab without errors)
- [ ] On the next legitimate backend/frontend compile failure inside a "domain" file, confirm Claude pushes a fix rather than stopping
- [ ] On the next genuine algorithmic change (e.g. modifying the BIBD scheduler logic), confirm Claude still stops and posts a review-request comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)